### PR TITLE
Bug 1021495 - Display bindings for queues with API

### DIFF
--- a/migration/versions/24a44075f9ce_create_binding_table.py
+++ b/migration/versions/24a44075f9ce_create_binding_table.py
@@ -1,0 +1,30 @@
+"""create Binding table
+
+Revision ID: 24a44075f9ce
+Revises: 641f40e01a9
+Create Date: 2016-05-10 11:52:34.849762
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '24a44075f9ce'
+down_revision = '641f40e01a9'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'bindings',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('exchange', sa.String(255)),
+        sa.Column('routing_key', sa.String(255)),
+        sa.Column('queue_name', sa.Unicode(255), sa.ForeignKey('queues.name')),
+    )
+
+
+def downgrade():
+    op.drop_table('bindings')

--- a/pulseguardian/dbinit.py
+++ b/pulseguardian/dbinit.py
@@ -7,6 +7,7 @@ import sys
 
 from pulseguardian import config, management as pulse_management
 from pulseguardian.model.base import db_session, init_db
+from pulseguardian.model.binding import Binding
 from pulseguardian.model.user import User
 from pulseguardian.model.pulse_user import PulseUser
 from pulseguardian.model.queue import Queue
@@ -30,6 +31,8 @@ def init_and_clear_db():
     # Clear the database of old data.
     for queue in Queue.query.all():
         db_session.delete(queue)
+    for binding in Binding.query.all():
+        db_session.delete(binding)
     for pulse_user in PulseUser.query.all():
         db_session.delete(pulse_user)
     for user in User.query.all():

--- a/pulseguardian/guardian.py
+++ b/pulseguardian/guardian.py
@@ -49,9 +49,9 @@ class PulseGuardian(object):
         db_queues = Queue.query.all()
 
         # Filter queues that are in the database but no longer on RabbitMQ.
-        alive_queues_names = set(q['name'] for q in queues)
-        deleted_queues = set(q for q in db_queues if q.name
-                             not in alive_queues_names)
+        alive_queues_names = {q['name'] for q in queues}
+        deleted_queues = {q for q in db_queues
+                          if q.name not in alive_queues_names}
 
         # Delete those queues.
         for queue in deleted_queues:
@@ -73,9 +73,8 @@ class PulseGuardian(object):
         # Filter bindings that are in the database but no longer on RabbitMQ.
         alive_bindings_names = {Binding.as_string(b['source'], b['routing_key'])
                                 for b in rabbit_bindings}
-
-        deleted_bindings = set(b for b in db_bindings if b.name
-                               not in alive_bindings_names)
+        deleted_bindings = {b for b in db_bindings
+                            if b.name not in alive_bindings_names}
 
         # Delete those bindings.
         for binding in deleted_bindings:

--- a/pulseguardian/guardian.py
+++ b/pulseguardian/guardian.py
@@ -65,7 +65,6 @@ class PulseGuardian(object):
         db_session.commit()
 
     def clear_deleted_bindings(self, queue_name):
-
         rabbit_bindings = pulse_management.queue_bindings(config.rabbit_vhost,
                                                           queue_name)
 
@@ -129,7 +128,9 @@ class PulseGuardian(object):
         for binding in bindings:
             db_binding = Binding.query.filter(
                 Binding.exchange == binding["source"],
-                Binding.routing_key == binding["routing_key"]).first()
+                Binding.routing_key == binding["routing_key"],
+                Binding.queue_name == queue.name
+                ).first()
 
             if not db_binding:
                 # need to create the binding in the DB

--- a/pulseguardian/management.py
+++ b/pulseguardian/management.py
@@ -64,6 +64,13 @@ def queue(vhost, queue):
     return _api_request('queues/{0}/{1}'.format(vhost, queue))
 
 
+def queue_bindings(vhost, queue):
+    vhost = quote(vhost, '')
+    queue = quote(queue, '')
+    bindings = _api_request('queues/{0}/{1}/bindings'.format(vhost, queue))
+    return [b for b in bindings if b["source"]]
+
+
 def delete_queue(vhost, queue):
     vhost = quote(vhost, '')
     queue = quote(queue, '')

--- a/pulseguardian/model/binding.py
+++ b/pulseguardian/model/binding.py
@@ -15,7 +15,6 @@ class Binding(Base):
     routing_key = Column(String(255))
     queue_name = Column(String(255), ForeignKey('queues.name'))
 
-
     @property
     def name(self):
         return Binding.as_string(self.exchange, self.routing_key)

--- a/pulseguardian/model/binding.py
+++ b/pulseguardian/model/binding.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from sqlalchemy import Column, ForeignKey, Integer, String
+
+from pulseguardian.model.base import Base
+
+
+class Binding(Base):
+    __tablename__ = 'bindings'
+
+    id = Column(Integer, primary_key=True)
+    exchange = Column(String(255))
+    routing_key = Column(String(255))
+    queue_name = Column(String(255), ForeignKey('queues.name'))
+
+
+    @property
+    def name(self):
+        return Binding.as_string(self.exchange, self.routing_key)
+
+    @staticmethod
+    def as_string(exchange, routing_key):
+        # make this available so functions outside this class will
+        # be consistent with the string format for comparisons.
+        return "{}-{}".format(exchange, routing_key)
+
+    def __repr__(self):
+        return "<Binding(exchange='{0}', routing_key='{1}')>".format(self.exchange,
+                                                                     self.routing_key)
+
+
+    __str__ = __repr__

--- a/pulseguardian/model/queue.py
+++ b/pulseguardian/model/queue.py
@@ -3,8 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
 
 from pulseguardian.model.base import Base
+from pulseguardian.model.binding import Binding
 
 
 class Queue(Base):
@@ -17,6 +19,8 @@ class Queue(Base):
     warned = Column(Boolean)
 
     durable = Column(Boolean, nullable=False, default=False)
+    bindings = relationship(Binding, cascade='save-update, merge, delete')
+
 
     def __repr__(self):
         return "<Queue(name='{0}', owner='{1}')>".format(self.name, self.owner)

--- a/pulseguardian/templates/queues_listing.html
+++ b/pulseguardian/templates/queues_listing.html
@@ -30,6 +30,16 @@
         </div>
       </div>
 
+      <div>
+        <h5>Bindings:</h5>
+        <ul>
+          {%  for binding in queue.bindings %}
+             <li>
+                <code>{{ binding.exchange }}</code> with <code>{{ binding.routing_key }}</code>
+             </li>
+          {% endfor %}
+        </ul>
+      </div>
     </li>
   {% endfor %}
 </ul>

--- a/pulseguardian/web.py
+++ b/pulseguardian/web.py
@@ -265,6 +265,17 @@ def delete_pulse_user(pulse_username):
     return jsonify(ok=False)
 
 
+# Read-Only API
+
+@app.route('/queue/<path:queue_name>/bindings', methods=["GET"])
+def bindings_listing(queue_name):
+    queue = Queue.query.get(queue_name)
+    bindings = []
+    if queue:
+        bindings = pulse_management.queue_bindings(vhost='/', queue=queue.name)
+    return jsonify({"queue_name": queue_name, "bindings": bindings})
+
+
 # Authentication related
 
 @app.route('/auth/login', methods=['POST'])


### PR DESCRIPTION
This PR is a follow-on to #15, so the first commit is shared with that PR.

This will show all bindings (exchange / routing key)
for each queue in the UI

This also adds an API to get current bindings for a queue
via queue/<queue_name>/bindings
