### PR TITLE
Bug 1321704 - Allow some queues exemption from auto-delete

### DIFF
--- a/migration/versions/4ea622b0c81d_add_unbounded_on_queue.py
+++ b/migration/versions/4ea622b0c81d_add_unbounded_on_queue.py
@@ -1,0 +1,24 @@
+"""add unbounded on queue
+
+Revision ID: 4ea622b0c81d
+Revises: 24a44075f9ce
+Create Date: 2016-12-22 15:30:52.739696
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4ea622b0c81d'
+down_revision = '24a44075f9ce'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('queues', sa.Column('unbounded', sa.Boolean, default=False))
+
+
+def downgrade():
+    op.drop_column('queues', 'unbounded')

--- a/pulseguardian/guardian.py
+++ b/pulseguardian/guardian.py
@@ -180,9 +180,11 @@ class PulseGuardian(object):
             if not queue:
                 continue
 
-            # If a queue is over the deletion size, regardless of it having an
-            # owner or not, delete it.
-            if queue.size > self.del_queue_size:
+            # If a queue is over the deletion size and ``unbounded`` is
+            # False (the default), then delete it regardless of it having
+            # an owner or not
+            # If ``unbounded`` is True, then let it grow indefinitely.
+            if queue.size > self.del_queue_size and not queue.unbounded:
                 logging.warning("Queue '{0}' deleted. Queue size = {1}; "
                                "del_queue_size = {2}".format(
                     queue.name, queue.size, self.del_queue_size))

--- a/pulseguardian/model/queue.py
+++ b/pulseguardian/model/queue.py
@@ -15,6 +15,8 @@ class Queue(Base):
     name = Column(String(255), primary_key=True)
     owner_id = Column(Integer, ForeignKey('pulse_users.id'), nullable=True)
     size = Column(Integer)
+    # whether the queue can grow beyond the deletion size without being deleted
+    unbounded = Column(Boolean, default=False)
 
     warned = Column(Boolean)
 

--- a/pulseguardian/templates/queues_listing.html
+++ b/pulseguardian/templates/queues_listing.html
@@ -19,6 +19,11 @@
         {% if queue.durable %}
           <small><span class="label label-primary">Durable</span></small>
         {% endif %}
+        {% if queue.unbounded %}
+          <small><span class="label label-primary"
+                       title="This queue will not be auto-deleted when it grows past the deletion size">Unbounded</span></small>
+        {% endif %}
+
       </h4>
 
       <div class="progress">


### PR DESCRIPTION
If you set ``unbounded`` in the ``queues`` table to True, then the query can grow in size beyond the set deletion size.