### PR TITLE
Bug 1068447 - Allow multiple owners of pulse users, part deux

### DIFF
--- a/migration/versions/1ff5c08b2ac_remove_pulse_user_owner_id_field.py
+++ b/migration/versions/1ff5c08b2ac_remove_pulse_user_owner_id_field.py
@@ -1,0 +1,33 @@
+"""remove pulse user 1 to many field
+
+Revision ID: 1ff5c08b2ac
+Revises: 4bd0784e2978
+Create Date: 2017-01-26 14:29:25.399344
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1ff5c08b2ac'
+down_revision = '4bd0784e2978'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    # Sqlite does not support dropping columns or constraints, so only do this
+    # on "real" databases.  Locally, we re-create the databases on dbinit
+    # anyway.  In addition: this field and constraint are a no-op since they're
+    # not used anymore in the code.
+    if bind.engine.name is not "sqlite":
+        op.drop_constraint('pulse_users_owner_id_fkey', 'pulse_users', 'foreignkey')
+        op.drop_column('pulse_users', 'owner_id')
+
+
+def downgrade():
+    op.add_column('pulse_users', sa.Column('owner_id', sa.Integer,
+                                           sa.ForeignKey('users.id')))

--- a/pulseguardian/model/pulse_user.py
+++ b/pulseguardian/model/pulse_user.py
@@ -20,7 +20,6 @@ class PulseUser(Base):
     __tablename__ = 'pulse_users'
 
     id = Column(Integer, primary_key=True)
-    owner_id = Column(Integer, ForeignKey('users.id'), nullable=True)
     username = Column(String(255), unique=True)
 
     queues = relationship(

--- a/pulseguardian/model/user.py
+++ b/pulseguardian/model/user.py
@@ -32,11 +32,6 @@ class User(Base):
                                cascade='save-update, merge, delete',
                                secondary=pulse_user_owners)
 
-    # TODO: Remove this in a follow-up commit.  Needed for migration.
-    old_pulse_users = relationship(PulseUser, backref='owner',
-                                   cascade='save-update, merge, delete')
-
-
     @staticmethod
     def new_user(email, admin=False):
         """Initializes a new user, generating a salt and encrypting


### PR DESCRIPTION
This just removes the now-defunct one-to-many field for ownership of a pulse-user