### PR TITLE
Bug 1335954: Add RESERVED_USERS_{REGEX,MESSAGE}

### DIFF
--- a/pulseguardian/config.py
+++ b/pulseguardian/config.py
@@ -43,6 +43,10 @@ rabbit_user = os.getenv('RABBIT_USER', 'guest')
 # Password of the RabbitMQ user.
 rabbit_password = os.getenv('RABBIT_PASSWORD', 'guest')
 
+# reserved users
+reserved_users_regex = os.getenv('RESERVED_USERS_REGEX', None)
+reserved_users_message = os.getenv('RESERVED_USERS_MESSAGE', None)
+
 # PulseGuardian
 warn_queue_size = int(os.getenv('WARN_QUEUE_SIZE', 2000))
 del_queue_size = int(os.getenv('DEL_QUEUE_SIZE', 8000))

--- a/pulseguardian/web.py
+++ b/pulseguardian/web.py
@@ -480,6 +480,10 @@ def register_handler():
                       "alphabetical character and contain only alphanumeric "
                       "characters, periods, underscores, and hyphens.")
 
+    if re.match(config.reserved_users_regex, username):
+        errors.append("The submitted username is reserved. "
+                      + config.reserved_users_message)
+
     # Checking if a user exists in RabbitMQ OR in our db
     try:
         user_response = pulse_management.user(username=username)

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -631,6 +631,29 @@ class WebTest(unittest.TestCase):
             "mick", ",  {},   {},{},".format(*self.all_emails))
         self.assertEquals(new_emails, set(self.all_emails))
 
+    def test_register_reserved_name(self):
+        try:
+            config.reserved_users_regex = 'rese[r]ved'
+            config.reserved_users_message = 'NO RESERVED NAMES'
+            with web.app.test_client() as c:
+                templates = "{}/pulseguardian/templates".format(os.getcwd())
+                c.application.template_folder = templates
+                with c.session_transaction() as sess:
+                    sess['email'] = CONSUMER_EMAIL
+                    sess['fake_account'] = True
+                    sess['logged_in'] = True
+
+                resp = c.post(
+                    '/register', data={
+                        "username": "reserved-name",
+                        "password": "ohXoof9yoo",
+                        "password-verification": "ohXoof9yoo",
+                        "owners-list": CONSUMER_EMAIL,
+                    })
+                self.assertIn(config.reserved_users_message, resp.data)
+        finally:
+            config.reserved_users_regex = None
+            config.reserved_users_message = None
 
 def setup_host():
     global pulse_cfg


### PR DESCRIPTION
The current reason for these options is to prohibit management of users
beginning with "taskcluster-", since those will be handled by tc-pulse
(which has a similar configuration to prevent it handling anything *not*
beginning with that prefix).

The design is sufficiently general that it could be used to carve out
other parts of the user namespace for other purposes, if that became
necessary.

This passes the same set of tests that master does (which is to say, two fail for me).  I tested the exclusion manually, and that seems to work.  I don't see tests for the charset regex, so perhaps they aren't necessary here, either?

I'm open to hearing about other ways of handling this.  I'm also not sure from a read-through if I need to make similar changes to the guaradian to prevent if from "guarding" these queues?